### PR TITLE
Makes Project ID settable

### DIFF
--- a/teamcity/locator.go
+++ b/teamcity/locator.go
@@ -24,6 +24,11 @@ func LocatorName(name string) Locator {
 	return Locator(url.QueryEscape("name:") + url.PathEscape(name))
 }
 
+// LocatorUUID creates a locator for Project/BuildType by UUID
+func LocatorUUID(uuid string) Locator {
+	return Locator(url.QueryEscape("uuid:") + uuid)
+}
+
 // LocatorKey creates a locator for Group by Key
 func LocatorKey(key string) Locator {
 	return Locator(url.QueryEscape("key:") + url.PathEscape(key))

--- a/teamcity/project.go
+++ b/teamcity/project.go
@@ -148,30 +148,6 @@ func (s *ProjectService) Update(project *Project) (*Project, error) {
 	return s.updateProject(LocatorUUID(project.UUID), project, false)
 }
 
-func (s *ProjectService) UpdateID(project *Project, newId string) (*Project, error) {
-	uuidLocator := LocatorUUID(project.UUID)
-	current, err := s.Get(uuidLocator)
-	if err != nil {
-		return nil, err
-	}
-
-	if newId == current.ID {
-		return current, nil
-	}
-
-	err = s.updateStringField(uuidLocator, "id", newId, "project id")
-	if err != nil {
-		return nil, err
-	}
-
-	out, err := s.Get(uuidLocator) //Refresh after update
-	if err != nil {
-		return nil, err
-	}
-
-	return out, nil
-}
-
 // Delete - Deletes a project
 func (s *ProjectService) Delete(id string) error {
 	err := s.restHelper.deleteByIDWithSling(s.sling.New(), id, "project")
@@ -203,6 +179,13 @@ func (s *ProjectService) updateProject(locator Locator, project *Project, isCrea
 		}
 	}
 
+	if current.ID != project.ID {
+		err := s.updateStringField(locator, "id", project.ID, "project id")
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	//Update Parent
 	if !isCreate {
 		// Only perform update if there is a change.
@@ -225,7 +208,7 @@ func (s *ProjectService) updateProject(locator Locator, project *Project, isCrea
 			return nil, err
 		}
 	}
-	out, err := s.GetByID(project.ID) //Refresh after update
+	out, err := s.Get(locator) //Refresh after update
 	if err != nil {
 		return nil, err
 	}

--- a/teamcity/project.go
+++ b/teamcity/project.go
@@ -80,6 +80,10 @@ func (p *Project) ProjectReference() *ProjectReference {
 	}
 }
 
+func (p *Project) Locator() Locator {
+	return LocatorUUID(p.UUID)
+}
+
 func newProjectService(base *sling.Sling, client *http.Client) *ProjectService {
 	sling := base.Path("projects/")
 	return &ProjectService{

--- a/teamcity/project.go
+++ b/teamcity/project.go
@@ -149,8 +149,13 @@ func (s *ProjectService) Update(project *Project) (*Project, error) {
 }
 
 // Delete - Deletes a project
+// Deprecated: Use DeleteLocator instead
 func (s *ProjectService) Delete(id string) error {
-	err := s.restHelper.deleteByIDWithSling(s.sling.New(), id, "project")
+	return s.DeleteLocator(LocatorID(id))
+}
+
+func (s *ProjectService) DeleteLocator(locator Locator) error {
+	err := s.restHelper.deleteByIDWithSling(s.sling.New(), locator.String(), "project")
 	return err
 }
 

--- a/teamcity/project_test.go
+++ b/teamcity/project_test.go
@@ -20,9 +20,27 @@ func TestProject_Create(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, actual)
 	assert.NotEmpty(t, actual.ID)
+	assert.NotEmpty(t, actual.UUID)
 
 	cleanUpProject(t, client, actual.ID)
 
+	assert.Equal(t, newProject.Name, actual.Name)
+	assert.Equal(t, newProject.Description, actual.Description)
+}
+
+func TestProject_CreateWithID(t *testing.T) {
+	newProject := getTestProjectData(testProjectId, "")
+	newProject.ID = "CustomID"
+
+	client := setup()
+	actual, err := client.Projects.Create(newProject)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+
+	cleanUpProject(t, client, actual.ID)
+
+	assert.Equal(t, newProject.ID, actual.ID)
 	assert.Equal(t, newProject.Name, actual.Name)
 	assert.Equal(t, newProject.Description, actual.Description)
 }
@@ -101,6 +119,24 @@ func TestProject_UpdateDescription(t *testing.T) {
 
 	actual, _ = client.Projects.GetByID(created.ID)
 	assert.Equal(t, "Updated Description", actual.Description)
+}
+
+func TestProject_UpdateID(t *testing.T) {
+	projectName := fmt.Sprintf("Project %d", time.Now().Unix())
+	project, _ := teamcity.NewProject(projectName, "", "")
+
+	client := setup()
+
+	created, err := client.Projects.Create(project)
+	require.NoError(t, err)
+	defer cleanUpProject(t, client, created.ID)
+
+	actual, _ := client.Projects.GetByUUID(created.UUID)
+	_, err = client.Projects.UpdateID(actual, "Updated_Id")
+	require.NoError(t, err)
+
+	actual, _ = client.Projects.GetByUUID(created.UUID)
+	assert.Equal(t, "Updated_Id", actual.ID)
 }
 
 func TestProject_UpdateParent(t *testing.T) {

--- a/teamcity/project_test.go
+++ b/teamcity/project_test.go
@@ -16,13 +16,12 @@ func TestProject_Create(t *testing.T) {
 	newProject := getTestProjectData(testProjectId, "")
 	client := setup()
 	actual, err := client.Projects.Create(newProject)
-
 	require.NoError(t, err)
+	defer cleanUpProject(t, client, actual.ID)
+
 	require.NotNil(t, actual)
 	assert.NotEmpty(t, actual.ID)
 	assert.NotEmpty(t, actual.UUID)
-
-	cleanUpProject(t, client, actual.ID)
 
 	assert.Equal(t, newProject.Name, actual.Name)
 	assert.Equal(t, newProject.Description, actual.Description)
@@ -64,6 +63,21 @@ func TestProject_CreateWithParent(t *testing.T) {
 	require.NotNil(t, actual.ParentProject)
 	assert.Equal(testProjectId, actual.ParentProject.ID)
 	assert.Equal("ProjectTest_ChildProject", actual.ID)
+}
+
+func TestProject_Delete(t *testing.T) {
+	newProject := getTestProjectData(testProjectId, "")
+	client := setup()
+	actual, err := client.Projects.Create(newProject)
+	require.NoError(t, err)
+
+	err = client.Projects.DeleteLocator(actual.Locator())
+	require.NoError(t, err)
+
+	deletedProject, err := client.Projects.Get(actual.Locator())
+	assert.Nil(t, deletedProject)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
 }
 
 func TestProject_UpdateWithSameParentDoesNotChangeName(t *testing.T) {

--- a/teamcity/project_test.go
+++ b/teamcity/project_test.go
@@ -131,8 +131,9 @@ func TestProject_UpdateID(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanUpProject(t, client, created.ID)
 
-	actual, _ := client.Projects.GetByUUID(created.UUID)
-	_, err = client.Projects.UpdateID(actual, "Updated_Id")
+	actual, _ := client.Projects.GetByID(created.ID)
+	actual.ID = "Updated_Id"
+	_, err = client.Projects.Update(actual)
 	require.NoError(t, err)
 
 	actual, _ = client.Projects.GetByUUID(created.UUID)

--- a/teamcity/rest_helper.go
+++ b/teamcity/rest_helper.go
@@ -50,7 +50,15 @@ func (r *restHelper) getCustom(path string, out interface{}, resourceDescription
 }
 
 func (r *restHelper) get(path string, out interface{}, resourceDescription string) error {
-	request, _ := r.sling.New().Get(path).Request()
+	return r.getWithFields(path, getFields{}, out, resourceDescription)
+}
+
+type getFields struct {
+	Fields string `url:"fields,omitempty"`
+}
+
+func (r *restHelper) getWithFields(path string, fields getFields, out interface{}, resourceDescription string) error {
+	request, _ := r.sling.New().Get(path).QueryStruct(fields).Request()
 	response, err := r.httpClient.Do(request)
 	if err != nil {
 		return err


### PR DESCRIPTION
Project IDs can be modified using the web interface and API requests. The UUID is a stable reference.